### PR TITLE
chore(ci): rename pr.yaml workflow to build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Pull request
+name: Build
 
 on:
   push:


### PR DESCRIPTION
Rename the pr.yaml workflow to build.yaml to better signal that it runs on both the `main` branch as well as pull requests.