### PR TITLE
feat(acme): allow custom ACME tenant population

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -247,10 +247,15 @@ jobs:
         id: export-cluster-state
         if: success() || steps.setup-cluster.outcome == 'failure' || steps.setup-cluster.outcome == 'success'
         run: |
-          kubectl cluster-info dump -o yaml --output-directory=./cluster-state --namespaces=ingress,greenstar
-          kubectl get gateways.gateway.networking.k8s.io -o yaml -A > ./cluster-state/gateways.yaml
-          kubectl get httproutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/httproutes.yaml
-          kubectl get tlsroutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/tlsroutes.yaml
+          kubectl cluster-info dump -o yaml --output-directory=./cluster-state -A
+          for ns in $(kubectl get namespaces -oname | cut -d '/' -f2); do
+            mkdir -p "./cluster-state/${ns}"
+            kubectl get jobs -o yaml -A > ./cluster-state/${ns}/jobs.yaml
+            kubectl get cronjobs -o yaml -A > ./cluster-state/${ns}/cronjobs.yaml
+            kubectl get gateways.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/gateways.yaml
+            kubectl get httproutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/httproutes.yaml
+            kubectl get tlsroutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/tlsroutes.yaml
+          done
 
       - name: Upload cluster state artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -250,11 +250,11 @@ jobs:
           kubectl cluster-info dump -o yaml --output-directory=./cluster-state -A
           for ns in $(kubectl get namespaces -oname | cut -d '/' -f2); do
             mkdir -p "./cluster-state/${ns}"
-            kubectl get jobs -o yaml -A > ./cluster-state/${ns}/jobs.yaml
-            kubectl get cronjobs -o yaml -A > ./cluster-state/${ns}/cronjobs.yaml
-            kubectl get gateways.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/gateways.yaml
-            kubectl get httproutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/httproutes.yaml
-            kubectl get tlsroutes.gateway.networking.k8s.io -o yaml -A > ./cluster-state/${ns}/tlsroutes.yaml
+            kubectl get jobs -o yaml -n "${ns}" > ./cluster-state/${ns}/jobs.yaml
+            kubectl get cronjobs -o yaml -n "${ns}" > ./cluster-state/${ns}/cronjobs.yaml
+            kubectl get gateways.gateway.networking.k8s.io -o yaml -n "${ns}" > ./cluster-state/${ns}/gateways.yaml
+            kubectl get httproutes.gateway.networking.k8s.io -o yaml -n "${ns}" > ./cluster-state/${ns}/httproutes.yaml
+            kubectl get tlsroutes.gateway.networking.k8s.io -o yaml -n "${ns}" > ./cluster-state/${ns}/tlsroutes.yaml
           done
 
       - name: Upload cluster state artifact

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -210,7 +210,7 @@ jobs:
         env:
           VERSION: "0.0.0+${{ github.sha }}"
         run: |
-          task setup-tenant-helm-values-files
+          task setup-tenants-values-file
           helm install greenstar oci://ghcr.io/${{ github.repository_owner }}/greenstar \
               --version "${VERSION}" \
               --create-namespace -n greenstar \

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -210,11 +210,13 @@ jobs:
         env:
           VERSION: "0.0.0+${{ github.sha }}"
         run: |
+          task setup-tenant-helm-values-files
           helm install greenstar oci://ghcr.io/${{ github.repository_owner }}/greenstar \
               --version "${VERSION}" \
               --create-namespace -n greenstar \
-              -f deploy/local/chart-ci-values.yaml \
-              --wait --wait-for-jobs
+              -f ./deploy/local/chart-ci-values.yaml \
+              -f ./hack/greenstar-tenants-values.yaml \
+              --wait --wait-for-jobs --debug
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -206,18 +206,21 @@ tasks:
       - setup-jaeger
       - setup-grafana
 
-  setup-tenant-helm-values-files:
+  setup-tenants-values-file:
     sources:
       - ./deploy/local/acme/*.yaml
     generates:
       - ./hack/greenstar-tenants-values.yaml
     cmds:
+      - mkdir -pv hack
+      - rm -fv ./hack/greenstar-tenants-values.yaml
+      - touch ./hack/greenstar-tenants-values.yaml
       - # noinspection YAMLSchemaValidation
         for: sources
         cmd: |
-          mkdir -pv ./hack && touch ./hack/greenstar-tenants-values.yaml
-          NAME="$(basename "{{ .ITEM }}")" CONTENT="$(cat "{{ .ITEM }}")" \
-            yq -i '.acme.files += [{"name": env(NAME), "content": env(CONTENT)}]' ./hack/greenstar-tenants-values.yaml
+          export NAME="$(basename "{{ .ITEM }}")"
+          export CONTENT="$(cat "{{ .ITEM }}")"
+          yq -i '.acme.files += [{"name": env(NAME), "content": env(CONTENT)}]' ./hack/greenstar-tenants-values.yaml
 
   enable-gcp-workload-identity-federation:
     deps: [create-cluster]
@@ -304,13 +307,10 @@ tasks:
         EOF
 
   dev:
-    deps:
-      - setup-observability
-      - setup-tenant-helm-values-files
-      - setup-frontend-geopify-helm-values-files
+    deps: [ setup-observability, setup-tenants-values-file ]
     cmds:
-      - '[[ -f ./hack/greenstar-server-values.yaml ]] || (mkdir -pv hack && touch ./hack/greenstar-server-values.yaml)'
-      - '[[ -f ./hack/greenstar-frontend-values.yaml ]] || (mkdir -pv hack && touch ./hack/greenstar-frontend-values.yaml)'
+      - touch ./hack/greenstar-frontend-values.yaml
+      - touch ./hack/greenstar-server-values.yaml
       - skaffold dev --tail=false
 
   test:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -273,8 +273,9 @@ tasks:
         kubectl delete configmap -n greenstar gcp-workload-identity-federation || true
         kubectl create configmap -n greenstar gcp-workload-identity-federation --from-file hack/credential-configuration.json
         mkdir -pv ./hack && touch ./hack/greenstar-server-values.yaml
-        yq -i '.server.volumes = [], .server.volumeMounts = []' ./hack/greenstar-server-values.yaml
-        echo ${GCP_PROJECT_ID}
+        yq -i '.server.extraEnv = (.server.extraEnv // {})' ./hack/greenstar-server-values.yaml
+        yq -i '.server.volumes = (.server.volumes // [])' ./hack/greenstar-server-values.yaml
+        yq -i '.server.volumeMounts = (.server.volumeMounts // [])' ./hack/greenstar-server-values.yaml
         cat <<EOF | yq -i ea 'select(fileIndex == 0) *+ select(fileIndex == 1)' ./hack/greenstar-server-values.yaml -
         server:
           extraEnv:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -223,7 +223,7 @@ tasks:
           yq -i '.acme.files += [{"name": env(NAME), "content": env(CONTENT)}]' ./hack/greenstar-tenants-values.yaml
 
   enable-gcp-workload-identity-federation:
-    deps: [create-cluster]
+    deps: [ create-cluster ]
     env:
       WHOAMI:
         sh: whoami

--- a/acme/src/main.ts
+++ b/acme/src/main.ts
@@ -68,13 +68,17 @@ async function main() {
         }
 
         console.info(`Creating account transactions for tenant ${tenantData.id}...`)
-        for (let account of tenantData.accounts) {
-            await generateAccountTransactions(tenantData.id, tenantData.defaultCurrency, account)
+        if (tenantData.accounts && tenantData.accounts.length) {
+            for (let account of tenantData.accounts) {
+                await generateAccountTransactions(tenantData.id, tenantData.defaultCurrency, account)
+            }
         }
 
         console.info(`Creating scrapers for tenant ${tenantData.id}...`)
-        for (let scraper of tenantData.scrapers) {
-            await generateScraper(tenantData.id, scraper)
+        if (tenantData.scrapers && tenantData.scrapers.length) {
+            for (let scraper of tenantData.scrapers) {
+                await generateScraper(tenantData.id, scraper)
+            }
         }
 
         console.info(`Finished processing tenant ${tenantData.id}`)

--- a/deploy/chart/templates/acmejob.tpl.yaml
+++ b/deploy/chart/templates/acmejob.tpl.yaml
@@ -4,6 +4,7 @@
 {{- $configMapName := printf "%s-%s" $prefix $componentName -}}
 {{- $tenantsConfigMapName := printf "%s-%s-tenants" $prefix $componentName -}}
 {{- /*------------------------------------------------------------------------------------------------------------*/ -}}
+{{- if .Values.acme.files }}
 ---
 
 apiVersion: v1
@@ -30,7 +31,10 @@ metadata:
     app.kubernetes.io/component: {{ $componentName | quote }}
   name: {{ $tenantsConfigMapName | quote }}
 data:
-{{ (.Files.Glob "files/tenants/*.yaml").AsConfig | indent 2 }}
+  {{- range .Values.acme.files }}
+  {{ .name }}: |
+    {{- toYaml .content | nindent 4 }}
+  {{- end }}
 
 ---
 
@@ -45,6 +49,7 @@ metadata:
     app.kubernetes.io/component: {{ $componentName | quote }}
   name: {{ printf "%s-%s" $prefix $componentName | quote }}
 spec:
+  activeDeadlineSeconds: 120
   template:
     metadata:
       labels:
@@ -105,3 +110,4 @@ spec:
       restartPolicy: OnFailure
       enableServiceLinks: false
       serviceAccountName: {{ $serviceAccountName | quote }}
+{{- end }}

--- a/deploy/chart/templates/acmejob.tpl.yaml
+++ b/deploy/chart/templates/acmejob.tpl.yaml
@@ -44,6 +44,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     {{- include "greenstar.commonLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $componentName | quote }}

--- a/deploy/chart/templates/acmejob.tpl.yaml
+++ b/deploy/chart/templates/acmejob.tpl.yaml
@@ -44,13 +44,11 @@ metadata:
   annotations:
     "helm.sh/hook": post-install, post-upgrade
     "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
   labels:
     {{- include "greenstar.commonLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $componentName | quote }}
   name: {{ printf "%s-%s" $prefix $componentName | quote }}
 spec:
-  activeDeadlineSeconds: 120
   template:
     metadata:
       labels:

--- a/deploy/chart/values.schema.json
+++ b/deploy/chart/values.schema.json
@@ -34,6 +34,21 @@
                 "extraEnv": {
                     "$ref": "#/$defs/extraEnv"
                 },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "content"],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "content": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
                 "image": {
                     "$ref": "#/$defs/image"
                 },

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -6,6 +6,7 @@ ingress:
 acme:
   extraArgs: []
   extraEnv: {}
+  files: []
   image:
     repository: ghcr.io/arikkfir-org/greenstar/acme
     tag: "local"

--- a/deploy/local/acme/acme.yaml
+++ b/deploy/local/acme/acme.yaml
@@ -1,11 +1,6 @@
 id: acme
 displayName: A.C.M.E
 defaultCurrency: ILS
-scrapers:
-  - id: bankYahav
-    type: bankYahav
-    parameters:
-      accountID: primaryCheckingAccount
 accounts:
   - id: employers
     icon: |

--- a/deploy/local/chart-ci-values.yaml
+++ b/deploy/local/chart-ci-values.yaml
@@ -1,6 +1,7 @@
 cleanup:
   cronjobs: false
   jobs: false
+
 ingress:
   domain: greenstar.test
 

--- a/deploy/local/chart-local-values.yaml
+++ b/deploy/local/chart-local-values.yaml
@@ -1,3 +1,7 @@
+cleanup:
+  jobs: false
+  cronjobs: false
+
 ingress:
   domain: greenstar.test
 

--- a/scripts/download-cluster-state.sh
+++ b/scripts/download-cluster-state.sh
@@ -25,7 +25,7 @@ if [[ -z "${RUN_ID}" ]]; then
   echo "Most recent commit: ${COMMIT}" >&2
 
   echo "Finding the last run of the verify workflow for commit ${COMMIT}..." >&2
-  RUN_ID=$(gh run list --repo "${REPO_NAME}" --workflow="Pull request" --commit="${COMMIT}" --json databaseId --jq '.[0].databaseId')
+  RUN_ID=$(gh run list --repo "${REPO_NAME}" --workflow="Build" --commit="${COMMIT}" --json databaseId --jq '.[0].databaseId')
 
   if [ -z "${RUN_ID}" ]; then
       echo "No verify workflow run found for commit ${COMMIT}" >&2

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,6 +49,11 @@ build:
     concurrency: 5
 deploy:
   helm:
+    flags:
+      install:
+        - --timeout=1m
+      upgrade:
+        - --timeout=1m
     releases:
       - name: greenstar
         chartPath: ./deploy/chart


### PR DESCRIPTION
Allow adding more sample tenants when installing the Helm chart, improving the developer experience. 

Custom ACME tenant files can now be placed in the `deploy/local/acme` directory, where each YAML file represents a single tenant. Each such file will be transformed into a `ConfigMap` entry upon deployment, which is read by the ACME job. In local environments, you can create files such as `deploy/local/acme/my-tenant.local.yaml` and it will be excluded from SCM given it's `.local.` string in its name.

Additional changes included are:
- GitHub Actions cluster state artifact includes more data from all namespaces
- Taskfile task `setup-tenant-helm-values-files` renamed to `setup-tenants-values-file`
- Fixed a bug in `enable-gcp-workload-identity-federation` task related to `hack/greenstar-server-values.yaml` generation
- Fixed crash in ACME job that occurred when no scrapers were defined for a tenant
- Fixed cluster-state download script to refer to the correct GitHub Actions workflow
- Add a one-minute timeout to local Skaffold setup to make failures propagate faster