### PR TITLE
fix(sql): enforce tenant ID constraints and adjust foreign keys

### DIFF
--- a/deploy/chart/files/migrations/V030__tenants.sql
+++ b/deploy/chart/files/migrations/V030__tenants.sql
@@ -1,8 +1,8 @@
 CREATE TABLE tenants
 (
-    id           TEXT PRIMARY KEY,
+    id           VARCHAR(10) PRIMARY KEY,
     created_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at   TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    display_name TEXT
+    display_name TEXT CONSTRAINT val_display_name_length CHECK (CHAR_LENGTH(display_name) > 0)
 );
 GRANT SELECT, DELETE, INSERT, UPDATE ON TABLE tenants TO greenstar_server;

--- a/deploy/chart/files/migrations/V040__accounts.sql
+++ b/deploy/chart/files/migrations/V040__accounts.sql
@@ -1,6 +1,6 @@
 CREATE TABLE accounts
 (
-    tenant_id    TEXT NOT NULL
+    tenant_id    VARCHAR(10) NOT NULL
         CONSTRAINT fk_accounts_tenant_id
             REFERENCES tenants
             ON UPDATE CASCADE ON DELETE CASCADE,
@@ -13,7 +13,9 @@ CREATE TABLE accounts
         CONSTRAINT val_icon_length CHECK (CHAR_LENGTH(icon) > 0),
     type         TEXT,
     parent_id    TEXT,
-    PRIMARY KEY (tenant_id, id),
-    FOREIGN KEY (tenant_id, parent_id) REFERENCES accounts (tenant_id, id) ON UPDATE CASCADE ON DELETE CASCADE
+    CONSTRAINT pk_accounts
+        PRIMARY KEY (tenant_id, id),
+    CONSTRAINT fk_accounts_parent_id
+        FOREIGN KEY (tenant_id, parent_id) REFERENCES accounts (tenant_id, id) ON UPDATE CASCADE ON DELETE CASCADE
 );
 GRANT SELECT, DELETE, INSERT, UPDATE ON TABLE accounts TO greenstar_server;

--- a/deploy/chart/files/migrations/V050__transactions.sql
+++ b/deploy/chart/files/migrations/V050__transactions.sql
@@ -19,9 +19,10 @@ CREATE TABLE transactions
         CONSTRAINT val_description_not_empty CHECK (CHAR_LENGTH(description) > 0),
     source_account_id TEXT       NOT NULL,
     target_account_id TEXT       NOT NULL,
-    tenant_id         TEXT       NOT NULL
+    tenant_id         VARCHAR(10) NOT NULL,
         CONSTRAINT fk_transactions_tenant_id
-            REFERENCES tenants
+            FOREIGN KEY (tenant_id)
+                REFERENCES tenants (id)
             ON UPDATE CASCADE ON DELETE CASCADE,
     CONSTRAINT fk_transactions_source_account_id
         FOREIGN KEY (tenant_id, source_account_id)

--- a/deploy/chart/files/migrations/V060__scrapers.sql
+++ b/deploy/chart/files/migrations/V060__scrapers.sql
@@ -47,7 +47,7 @@ VALUES ('bankYahav', 'accountID', 'Checking Account', 'account');
 
 CREATE TABLE scrapers
 (
-    tenant_id       TEXT NOT NULL
+    tenant_id       VARCHAR(10) NOT NULL
         CONSTRAINT fk_scrapers_tenant_id
             REFERENCES tenants
             ON UPDATE CASCADE ON DELETE CASCADE,


### PR DESCRIPTION
Update SQL migrations to replace `TEXT` with `VARCHAR(10)` for tenant ID columns in `accounts`, `transactions`, `scrapers`, and `tenants` tables.

Add explicit constraints for primary and foreign keys to improve schema clarity and consistency. Include a non-empty check for `display_name` in `tenants`.