### PR TITLE
refactor(graphql)!: make all Void mutations actually return void

### DIFF
--- a/acme/src/graphql/graphql.ts
+++ b/acme/src/graphql/graphql.ts
@@ -136,12 +136,12 @@ export type Mutation = {
   createScraper: Scraper;
   createTenant: Tenant;
   createTransaction: Transaction;
-  deleteAccount?: Maybe<Scalars['Void']['output']>;
-  deleteScraper?: Maybe<Scalars['Void']['output']>;
+  deleteAccount: Scalars['Void']['output'];
+  deleteScraper: Scalars['Void']['output'];
   deleteTenant?: Maybe<Scalars['Void']['output']>;
-  deleteTransaction?: Maybe<Scalars['Void']['output']>;
+  deleteTransaction: Scalars['Void']['output'];
   moveAccount: Account;
-  noOp?: Maybe<Scalars['Void']['output']>;
+  noOp: Scalars['Void']['output'];
 };
 
 

--- a/frontend/src/graphql/graphql.ts
+++ b/frontend/src/graphql/graphql.ts
@@ -136,12 +136,12 @@ export type Mutation = {
   createScraper: Scraper;
   createTenant: Tenant;
   createTransaction: Transaction;
-  deleteAccount?: Maybe<Scalars['Void']['output']>;
-  deleteScraper?: Maybe<Scalars['Void']['output']>;
+  deleteAccount: Scalars['Void']['output'];
+  deleteScraper: Scalars['Void']['output'];
   deleteTenant?: Maybe<Scalars['Void']['output']>;
-  deleteTransaction?: Maybe<Scalars['Void']['output']>;
+  deleteTransaction: Scalars['Void']['output'];
   moveAccount: Account;
-  noOp?: Maybe<Scalars['Void']['output']>;
+  noOp: Scalars['Void']['output'];
 };
 
 

--- a/ratesjob/src/graphql/graphql.ts
+++ b/ratesjob/src/graphql/graphql.ts
@@ -136,12 +136,12 @@ export type Mutation = {
   createScraper: Scraper;
   createTenant: Tenant;
   createTransaction: Transaction;
-  deleteAccount?: Maybe<Scalars['Void']['output']>;
-  deleteScraper?: Maybe<Scalars['Void']['output']>;
+  deleteAccount: Scalars['Void']['output'];
+  deleteScraper: Scalars['Void']['output'];
   deleteTenant?: Maybe<Scalars['Void']['output']>;
-  deleteTransaction?: Maybe<Scalars['Void']['output']>;
+  deleteTransaction: Scalars['Void']['output'];
   moveAccount: Account;
-  noOp?: Maybe<Scalars['Void']['output']>;
+  noOp: Scalars['Void']['output'];
 };
 
 

--- a/server/src/data/data_layer.ts
+++ b/server/src/data/data_layer.ts
@@ -575,9 +575,8 @@ export class DataLayerImpl implements DataLayer {
     }
 
     async deleteAccount(args: MutationDeleteAccountArgs): Promise<void> {
-        const row = await this.accountsDAO.deleteAccount(args.tenantID, args.id)
+        await this.accountsDAO.deleteAccount(args.tenantID, args.id)
         this.account.clear({ tenantID: args.tenantID, accountID: args.id })
-        return row
     }
 
     async deleteScraper(args: MutationDeleteScraperArgs): Promise<void> {
@@ -596,9 +595,8 @@ export class DataLayerImpl implements DataLayer {
     }
 
     async deleteTransaction(args: MutationDeleteTransactionArgs): Promise<void> {
-        const row = await this.transactionsDAO.deleteTransaction(args.tenantID, args.id)
+        await this.transactionsDAO.deleteTransaction(args.tenantID, args.id)
         this.transaction.clear({ tenantID: args.tenantID, txID: args.id })
-        return row
     }
 
     async fetchAccount(tenantID: Tenant["id"], accountID: Account["id"]): Promise<Account | null> {
@@ -755,7 +753,7 @@ export class DataLayerImpl implements DataLayer {
     }
 
     async fetchTransaction(tenantID: Tenant["id"], txID: Transaction["id"]): Promise<Transaction | null> {
-        return await this.transaction.load({tenantID, txID})
+        return await this.transaction.load({ tenantID, txID })
     }
 
     async fetchTransactions(

--- a/server/src/resolvers.ts
+++ b/server/src/resolvers.ts
@@ -16,7 +16,7 @@ import { DateTimeScalar } from "./schema/scalars-luxon-datetime.js"
 import { VoidScalar } from "./schema/scalars-void.js"
 
 import { TransactionsSummaryResult } from "./data/transactions.js"
-import pkg from "../package.json" with { type: "json" };
+import pkg from "../package.json" with { type: "json" }
 
 export interface AccountRow extends Account {
     tenantID: Tenant["id"],
@@ -42,7 +42,8 @@ export interface ScraperParameterRow extends ScraperParameter {
 
 export const GraphResolvers: Resolvers<Context> = {
     Mutation: {
-        noOp: async (_: any, _args, _ctx) => null,
+        noOp: async (_: any, _args, _ctx) => {
+        },
         createAccount: async (_: any, args, ctx) => ctx.data.createAccount(args),
         createCurrencyRate: async (_: any, args, ctx) => ctx.data.createCurrencyRate(args),
         createScraper: async (_: any, args, ctx) => ctx.data.createScraper(args),

--- a/server/src/schema/accounts.graphql
+++ b/server/src/schema/accounts.graphql
@@ -47,6 +47,6 @@ extend type Mutation {
         icon: String,
         type: AccountType,
     ): Account!
-    deleteAccount(tenantID: ID!, id: ID!): Void
+    deleteAccount(tenantID: ID!, id: ID!): Void!
     moveAccount(tenantID: ID!, accountID: ID!, targetParentAccountID: ID): Account!
 }

--- a/server/src/schema/commons.graphql
+++ b/server/src/schema/commons.graphql
@@ -3,7 +3,7 @@ type Query {
 }
 
 type Mutation {
-    noOp: Void
+    noOp: Void!
 }
 
 enum SortDirection {

--- a/server/src/schema/graphql.ts
+++ b/server/src/schema/graphql.ts
@@ -137,12 +137,12 @@ export type Mutation = {
   createScraper: Scraper;
   createTenant: Tenant;
   createTransaction: Transaction;
-  deleteAccount?: Maybe<Scalars['Void']['output']>;
-  deleteScraper?: Maybe<Scalars['Void']['output']>;
+  deleteAccount: Scalars['Void']['output'];
+  deleteScraper: Scalars['Void']['output'];
   deleteTenant?: Maybe<Scalars['Void']['output']>;
-  deleteTransaction?: Maybe<Scalars['Void']['output']>;
+  deleteTransaction: Scalars['Void']['output'];
   moveAccount: Account;
-  noOp?: Maybe<Scalars['Void']['output']>;
+  noOp: Scalars['Void']['output'];
 };
 
 
@@ -609,12 +609,12 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createScraper?: Resolver<ResolversTypes['Scraper'], ParentType, ContextType, RequireFields<MutationCreateScraperArgs, 'displayName' | 'parameters' | 'scraperTypeID' | 'tenantID'>>;
   createTenant?: Resolver<ResolversTypes['Tenant'], ParentType, ContextType, RequireFields<MutationCreateTenantArgs, 'displayName' | 'id'>>;
   createTransaction?: Resolver<ResolversTypes['Transaction'], ParentType, ContextType, RequireFields<MutationCreateTransactionArgs, 'tx'>>;
-  deleteAccount?: Resolver<Maybe<ResolversTypes['Void']>, ParentType, ContextType, RequireFields<MutationDeleteAccountArgs, 'id' | 'tenantID'>>;
-  deleteScraper?: Resolver<Maybe<ResolversTypes['Void']>, ParentType, ContextType, RequireFields<MutationDeleteScraperArgs, 'id' | 'scraperTypeID' | 'tenantID'>>;
+  deleteAccount?: Resolver<ResolversTypes['Void'], ParentType, ContextType, RequireFields<MutationDeleteAccountArgs, 'id' | 'tenantID'>>;
+  deleteScraper?: Resolver<ResolversTypes['Void'], ParentType, ContextType, RequireFields<MutationDeleteScraperArgs, 'id' | 'scraperTypeID' | 'tenantID'>>;
   deleteTenant?: Resolver<Maybe<ResolversTypes['Void']>, ParentType, ContextType, RequireFields<MutationDeleteTenantArgs, 'id'>>;
-  deleteTransaction?: Resolver<Maybe<ResolversTypes['Void']>, ParentType, ContextType, RequireFields<MutationDeleteTransactionArgs, 'id' | 'tenantID'>>;
+  deleteTransaction?: Resolver<ResolversTypes['Void'], ParentType, ContextType, RequireFields<MutationDeleteTransactionArgs, 'id' | 'tenantID'>>;
   moveAccount?: Resolver<ResolversTypes['Account'], ParentType, ContextType, RequireFields<MutationMoveAccountArgs, 'accountID' | 'tenantID'>>;
-  noOp?: Resolver<Maybe<ResolversTypes['Void']>, ParentType, ContextType>;
+  noOp?: Resolver<ResolversTypes['Void'], ParentType, ContextType>;
 };
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = {

--- a/server/src/schema/scrapers.graphql
+++ b/server/src/schema/scrapers.graphql
@@ -52,7 +52,7 @@ extend type Mutation {
         scraperTypeID: ID!,
         parameters: [ScraperParameterInput!]!
     ): Scraper!
-    deleteScraper(tenantID: ID!, scraperTypeID: ID!, id: ID!): Void
+    deleteScraper(tenantID: ID!, scraperTypeID: ID!, id: ID!): Void!
 }
 
 input ScraperParameterInput {

--- a/server/src/schema/transactions.graphql
+++ b/server/src/schema/transactions.graphql
@@ -36,7 +36,7 @@ type TransactionsResult {
 
 extend type Mutation {
     createTransaction(tx: CreateTransaction!): Transaction!
-    deleteTransaction(tenantID: ID!, id: ID!): Void
+    deleteTransaction(tenantID: ID!, id: ID!): Void!
 }
 
 input CreateTransaction {


### PR DESCRIPTION
Make `Void` mutation outputs non-nullable in GraphQL schema to enforce consistent behavior across `deleteAccount`, `deleteTransaction`, `deleteScraper`, and `noOp` mutations. This ensures clients must handle responses explicitly, improving reliability and predictability.

Additionally:
- Adjust resolver implementations to align with new schema behavior.
- Remove unnecessary return of result rows from `deleteAccount` and `deleteTransaction` in the data layer.