### PR TITLE
feat(server): use Helm job to perform SQL migration

### DIFF
--- a/deploy/chart/templates/acmejob.tpl.yaml
+++ b/deploy/chart/templates/acmejob.tpl.yaml
@@ -55,31 +55,6 @@ spec:
         {{- include "greenstar.commonLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ $componentName | quote }}
     spec:
-      initContainers:
-
-        # Wait for GraphQL server to be available
-        - image: alpine/curl:8.14.1
-          args:
-            - --fail-with-body
-            - --location
-            - --silent
-            - --show-error
-            - --verbose
-            - --header
-            - "apollo-require-preflight: true"
-            - "$(GRAPHQL_API_URL)/graphql?query=%7B__typename%7D"
-          env:
-            - name: GRAPHQL_API_URL
-              value: http://greenstar-server/graphql
-          name: wait-for-graphql-server
-          resources:
-            limits:
-              cpu: "100m"
-              memory: "32Mi"
-            requests:
-              cpu: "100m"
-              memory: "16Mi"
-
       containers:
         - env:
             - name: GRAPHQL_API_URL

--- a/deploy/chart/templates/postgres.tpl.yaml
+++ b/deploy/chart/templates/postgres.tpl.yaml
@@ -4,6 +4,7 @@
 {{- $serviceName := printf "%s-%s" $prefix $componentName -}}
 {{- $secretName := printf "%s-%s" $prefix $componentName -}}
 {{- $dataPVCName := printf "%s-%s-data" $prefix $componentName -}}
+{{- $migrationsConfigMapName := printf "%s-%s-migrations" $prefix $componentName -}}
 {{- $migrationUserPassword := default (randAlphaNum 16) .Values.server.migrate.postgresPassword -}}
 {{- $postgresUserPassword := default (randAlphaNum 16) .Values.postgres.password -}}
 {{- $serverUserPassword := default (randAlphaNum 16) .Values.server.postgresPassword -}}
@@ -85,6 +86,85 @@ stringData:
     {{- $vars = merge $vars (dict "serverUserPassword" $serverUserPassword) -}}
     {{- $rendered := tpl $file $vars -}}
     {{ $rendered | nindent 4 }}
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    "helm.sh/hook": pre-upgrade, post-install
+    "helm.sh/hook-weight": "-21"
+  labels:
+    {{- include "greenstar.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $componentName | quote }}
+  name: {{ $migrationsConfigMapName | quote }}
+data:
+{{ (.Files.Glob "files/migrations/*.sql").AsConfig | indent 2 }}
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": pre-upgrade, post-install
+    "helm.sh/hook-weight": "-20"
+  labels:
+    {{- include "greenstar.commonLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ $componentName | quote }}
+  name: {{ printf "%s-%s-migrate" $prefix $componentName | quote }}
+spec:
+  activeDeadlineSeconds: 300
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        {{- include "greenstar.commonLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ $componentName | quote }}
+    spec:
+      containers:
+        - image: flyway/flyway:11.3.1-alpine
+          args: [ migrate ]
+          env:
+            - name: FLYWAY_URL
+              value: jdbc:postgresql://{{ printf "%s-postgres" $prefix }}:5432/greenstar?connectTimeout=3&sslmode=disable
+            - name: FLYWAY_USER
+              value: "greenstar_migration"
+            - name: FLYWAY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-%s" $prefix $componentName | quote }}
+                  key: migration-user-pwd
+                  optional: false
+            - name: FLYWAY_LOCATIONS
+              value: "filesystem:/var/lib/flyway/sql"
+            - name: FLYWAY_OUTPUT_QUERY_RESULTS
+              value: "true"
+            {{- range $key, $value := .Values.server.migrate.extraEnv }}
+            - name: {{ $key | quote }}
+              {{ toYaml $value | nindent 14 }}
+            {{- end }}
+          name: flyway
+          resources:
+            limits:
+              cpu: {{ required "Server migration CPU limit is required" .Values.server.migrate.resources.limits.cpu | quote }}
+              memory: {{ required "Server migration RAM limit is required" .Values.server.migrate.resources.limits.memory | quote }}
+            requests:
+              cpu: {{ required "Server migration CPU request is required" .Values.server.migrate.resources.requests.cpu | quote }}
+              memory: {{ required "Server migration RAM request is required" .Values.server.migrate.resources.requests.memory | quote }}
+          volumeMounts:
+            - name: migrations
+              readOnly: true
+              mountPath: /var/lib/flyway/sql
+      volumes:
+        - name: migrations
+          configMap:
+            name: {{ $migrationsConfigMapName | quote }}
+            optional: false
+      restartPolicy: OnFailure
+      enableServiceLinks: false
+      serviceAccountName: {{ $serviceAccountName | quote }}
 
 ---
 

--- a/deploy/chart/templates/ratesjob.tpl.yaml
+++ b/deploy/chart/templates/ratesjob.tpl.yaml
@@ -38,32 +38,6 @@ spec:
             {{- include "greenstar.commonLabels" . | nindent 12 }}
             app.kubernetes.io/component: {{ $componentName | quote }}
         spec:
-
-          initContainers:
-
-            # Wait for GraphQL server to be available
-            - image: alpine/curl:8.14.1
-              args:
-                - --fail-with-body
-                - --location
-                - --silent
-                - --show-error
-                - --verbose
-                - --header
-                - "apollo-require-preflight: true"
-                - "$(GRAPHQL_API_URL)/graphql?query=%7B__typename%7D"
-              env:
-                - name: GRAPHQL_API_URL
-                  value: http://greenstar-server/graphql
-              name: wait-for-graphql-server
-              resources:
-                limits:
-                  cpu: "100m"
-                  memory: "32Mi"
-                requests:
-                  cpu: "100m"
-                  memory: "16Mi"
-
           containers:
             - env:
                 - name: GRAPHQL_API_URL
@@ -104,31 +78,6 @@ spec:
         {{- include "greenstar.commonLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ $componentName | quote }}
     spec:
-
-      initContainers:
-
-        # Wait for GraphQL server to be available
-        - image: alpine/curl:8.14.1
-          args:
-            - --fail-with-body
-            - --location
-            - --silent
-            - --show-error
-            - --verbose
-            - --header
-            - "apollo-require-preflight: true"
-            - "$(GRAPHQL_API_URL)/graphql?query=%7B__typename%7D"
-          env:
-            - name: GRAPHQL_API_URL
-              value: http://greenstar-server/graphql
-          name: wait-for-graphql-server
-          resources:
-            limits:
-              cpu: "100m"
-              memory: "32Mi"
-            requests:
-              cpu: "100m"
-              memory: "16Mi"
 
       containers:
         - env:

--- a/deploy/chart/templates/server.tpl.yaml
+++ b/deploy/chart/templates/server.tpl.yaml
@@ -2,7 +2,7 @@
 {{- $componentName := "server" -}}
 {{- $serviceAccountName := printf "%s-%s" $prefix $componentName -}}
 {{- $serviceName := printf "%s-%s" $prefix $componentName -}}
-{{- $migrationsConfigMapName := printf "%s-%s-migrations" $prefix $componentName -}}
+{{- $dataPVCName := printf "%s-%s-data" $prefix $componentName -}}
 {{- /*------------------------------------------------------------------------------------------------------------*/ -}}
 ---
 
@@ -42,14 +42,21 @@ spec:
 ---
 
 apiVersion: v1
-kind: ConfigMap
+kind: PersistentVolumeClaim
 metadata:
   labels:
     {{- include "greenstar.commonLabels" . | nindent 4 }}
     app.kubernetes.io/component: {{ $componentName | quote }}
-  name: {{ $migrationsConfigMapName | quote }}
-data:
-{{ (.Files.Glob "files/migrations/*.sql").AsConfig | indent 2 }}
+  name: {{ $dataPVCName | quote }}
+spec:
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+    limits:
+      storage: 4Gi
 
 ---
 
@@ -77,81 +84,6 @@ spec:
         {{- include "greenstar.commonLabels" . | nindent 8 }}
         app.kubernetes.io/component: {{ $componentName | quote }}
     spec:
-      initContainers:
-
-        # Wait for Postgres to be available
-        - image: {{ printf "postgres:%s" .Values.postgres.version | quote }}
-          args:
-            - bash
-            - -c
-            - "while ! psql -c \"\\q\"; do sleep 1; done"
-          env:
-            - name: PGHOST
-              value: {{ printf "%s-postgres" $prefix | quote }}
-            - name: PGPORT
-              value: "5432"
-            - name: PGDATABASE
-              value: "greenstar"
-            - name: PGUSER
-              value: "greenstar_server"
-            - name: PGPASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-postgres" $prefix | quote }}
-                  key: server-user-pwd
-                  optional: false
-            - name: PGAPPNAME
-              value: {{ printf "%s-%s-wait-for-postgres" $prefix $componentName | quote }}
-            - name: PGCONNECT_TIMEOUT
-              value: "3"
-            - name: PGIDLE_TIMEOUT
-              value: "10"
-            - name: PGSSLMODE
-              value: "disable"
-          name: wait-for-postgres
-          resources:
-            limits:
-              cpu: "100m"
-              memory: "32Mi"
-            requests:
-              cpu: "100m"
-              memory: "16Mi"
-
-        # Database migrations initialization container
-        - image: flyway/flyway:11.3.1-alpine
-          args: [ migrate ]
-          env:
-            - name: FLYWAY_URL
-              value: jdbc:postgresql://{{ printf "%s-postgres" $prefix }}:5432/greenstar?connectTimeout=3&sslmode=disable
-            - name: FLYWAY_USER
-              value: "greenstar_migration"
-            - name: FLYWAY_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ printf "%s-postgres" $prefix | quote }}
-                  key: migration-user-pwd
-                  optional: false
-            - name: FLYWAY_LOCATIONS
-              value: "filesystem:/var/lib/flyway/sql"
-            - name: FLYWAY_OUTPUT_QUERY_RESULTS
-              value: "true"
-            {{- range $key, $value := .Values.server.migrate.extraEnv }}
-            - name: {{ $key | quote }}
-              {{ toYaml $value | nindent 14 }}
-            {{- end }}
-          name: flyway
-          resources:
-            limits:
-              cpu: {{ required "Server migration CPU limit is required" .Values.server.migrate.resources.limits.cpu | quote }}
-              memory: {{ required "Server migration RAM limit is required" .Values.server.migrate.resources.limits.memory | quote }}
-            requests:
-              cpu: {{ required "Server migration CPU request is required" .Values.server.migrate.resources.requests.cpu | quote }}
-              memory: {{ required "Server migration RAM request is required" .Values.server.migrate.resources.requests.memory | quote }}
-          volumeMounts:
-            - name: migrations
-              readOnly: true
-              mountPath: /var/lib/flyway/sql
-
       containers:
         - image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
@@ -251,20 +183,23 @@ spec:
             failureThreshold: 10
             timeoutSeconds: 1
             terminationGracePeriodSeconds: 60
-          {{- if not (empty .Values.server.volumeMounts) }}
           volumeMounts:
+            - name: data
+              readOnly: false
+              mountPath: /var/lib/greenstar/data
+            {{- if not (empty .Values.server.volumeMounts) }}
             {{- toYaml .Values.server.volumeMounts | nindent 12 }}
-          {{- end }}
+            {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ $serviceAccountName | quote }}
       volumes:
-        - name: migrations
-          configMap:
-            name: {{ $migrationsConfigMapName | quote }}
-            optional: false
-      {{- if not (empty .Values.server.volumes) }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ $dataPVCName | quote }}
+            readOnly: false
+        {{- if not (empty .Values.server.volumes) }}
         {{- toYaml .Values.server.volumes | nindent 8 }}
-      {{- end }}
+        {{- end }}
 
 {{- if .Values.server.ingress.enabled }}
 


### PR DESCRIPTION
Refactor Flyway migrations to a Kubernetes job with hooks for pre-upgrade and post-install. This allows removing the init-containers in currency rates & ACME jobs that wait until PostgreSQL/server are available.

Additionally, add a PVC to the server micro-service for files upload storage.